### PR TITLE
Throw exception when ssh2 extension isn't installed

### DIFF
--- a/src/Backend/Ssh2.php
+++ b/src/Backend/Ssh2.php
@@ -218,11 +218,18 @@ class Ssh2 implements Backend {
 	 * Return array of supported protocols
 	 */
 	public static function getAvailableProtocols() {
-		$protocols = array();
-		if(function_exists('ssh2_connect')) {
-			$protocols = array('ssh','scp','sftp');
+		return array('ssh','scp','sftp');
+	}
+
+	/**
+	 * Check if ssh2 extension is installed
+	 */
+	public static function isSupported() {
+		if(!function_exists('ssh2_connect')) {
+			return false;
 		}
-		return $protocols;
+
+		return true;
 	}
 	
 	/**

--- a/src/Bridge.php
+++ b/src/Bridge.php
@@ -30,7 +30,11 @@ class Bridge {
 		
 		//Primary option, try to use ssh2 functions as backend
 		if(in_array($scheme, Ssh2::getAvailableProtocols())) {
-			$this->backend = new Ssh2($url, $options);
+			if(Ssh2::isSupported()) {
+				$this->backend = new Ssh2($url, $options);
+			} else {
+				throw new \Exception("ssh2 PECL extension is not installed. Please install it to use ssh.");
+			}
 		}
 		//Secondary option, try to use ftp functions as backend
 		else if(in_array($scheme, Ftp::getAvailableProtocols())) {


### PR DESCRIPTION
As ssh2 isn't installed by default, it was uninformative to just get a "unsupported protocol ssh" message. Added a check that shows a more helpful message.

FTP and CURL should have the same checks, but at least they're installed by default and safer.