### PR TITLE
Port is cast to Int for ssh2_connect

### DIFF
--- a/src/Backend/Ssh2.php
+++ b/src/Backend/Ssh2.php
@@ -44,7 +44,8 @@ class Ssh2 implements Backend {
 		//Initialize connection
 		$host = urldecode($parsedUrl['host']);
 		if(isset($parsedUrl['port']) && $parsedUrl['port']) {
-			$port = urldecode('port');
+			//Port should be an integer
+			$port = (int) urldecode('port');
 			$this->ssh = ssh2_connect($host, $port);
 		}
 		else {


### PR DESCRIPTION
The port is cast to integer to prevent a bug with `ssh2_connect` failing when the port is passed as string.